### PR TITLE
Fix `RangeError`when header length + 1 is not multiple of 4

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -5,8 +5,8 @@ async function loadPly(content) {
     const contentStart = new TextDecoder('utf-8').decode(content.slice(0, 2000))
     const headerEnd = contentStart.indexOf('end_header') + 'end_header'.length + 1
     const [header] = contentStart.split('end_header')  // Header (string)
-    const contentSlice = content.slice(headerEnd); // headerEnd may not be a multiple of 4, so we need to slice the buffer
-    const array = new Float32Array(contentSlice);
+    const contentSlice = content.slice(headerEnd) // headerEnd may not be a multiple of 4, so we need to slice the buffer
+    const array = new Float32Array(contentSlice)
 
     // Get number of gaussians
     const regex = /element vertex (\d+)/

--- a/src/loader.js
+++ b/src/loader.js
@@ -6,7 +6,7 @@ async function loadPly(content) {
     const headerEnd = contentStart.indexOf('end_header') + 'end_header'.length + 1
     const [header] = contentStart.split('end_header')  // Header (string)
     const contentSlice = content.slice(headerEnd) // headerEnd may not be a multiple of 4, so we need to slice the buffer
-    const array = new Float32Array(contentSlice)
+    const array = new Float32Array(contentSlice) // Packed gaussian data
 
     // Get number of gaussians
     const regex = /element vertex (\d+)/

--- a/src/loader.js
+++ b/src/loader.js
@@ -5,7 +5,8 @@ async function loadPly(content) {
     const contentStart = new TextDecoder('utf-8').decode(content.slice(0, 2000))
     const headerEnd = contentStart.indexOf('end_header') + 'end_header'.length + 1
     const [header] = contentStart.split('end_header')  // Header (string)
-    const array = new Float32Array(content, headerEnd) // Packed float32 data
+    const contentSlice = content.slice(headerEnd); // headerEnd may not be a multiple of 4, so we need to slice the buffer
+    const array = new Float32Array(contentSlice);
 
     // Get number of gaussians
     const regex = /element vertex (\d+)/


### PR DESCRIPTION
I was running into the below error in `loader.js: 8`
```
RangeError: start offset of Float32Array should be a multiple of 4
```
The header of your example `.ply` file happens to have length `1531`, so the float data starts at 1532, which is multiple of 4, hence no issue.  The one I tried to upload had length `1530`, which was then resulting the above error. 

I believe the proposed changes would prevent the issue for any header length.

Note: In case you are interested, the reason for my header being 1 byte shorter is that my gaussian model is much smaller, hence where in your header it says: `element vertex 1087406`, in mine it says: `element vertex 263123`, as opposed to your 

PS. Thank you for this awesome tool!